### PR TITLE
更新MCVersion.cs以试图使bot正确支持1.19

### DIFF
--- a/CFPABot/Utils/MCVersion.cs
+++ b/CFPABot/Utils/MCVersion.cs
@@ -12,7 +12,9 @@ namespace CFPABot.Utils
         v116,
         v118,
         v116fabric,
-        v118fabric
+        v118fabric,
+        v119// ,
+        // v119fabric
     }
 
     public static class MCVersionExtensions
@@ -26,6 +28,8 @@ namespace CFPABot.Utils
                 MCVersion.v118 => "1.18",
                 MCVersion.v116fabric => "1.16-fabric",
                 MCVersion.v118fabric => "1.18-fabric",
+                MCVersion.v119 => "1.19",
+                // MCVersion.v119fabric => "1.19-fabric",
                 _ => throw new ArgumentOutOfRangeException(nameof(version), version, null)
             };
         }
@@ -39,6 +43,8 @@ namespace CFPABot.Utils
                 MCVersion.v118 => "1.18",
                 MCVersion.v116fabric => "1.16",
                 MCVersion.v118fabric => "1.18",
+                MCVersion.v119 => "1.19",
+                // MCVersion.v119fabric => "1.19",
                 _ => throw new ArgumentOutOfRangeException(nameof(version), version, null)
             };
         }
@@ -52,6 +58,8 @@ namespace CFPABot.Utils
                 "1.18" => MCVersion.v118,
                 "1.16-fabric" => MCVersion.v116fabric,
                 "1.18-fabric" => MCVersion.v118fabric,
+                "1.19" => MCVersion.v119,
+                // "1.19-fabric" => MCVersion.v119fabric,
                 _ => throw new ArgumentOutOfRangeException(nameof(version), version, null)
             };
         }
@@ -64,6 +72,8 @@ namespace CFPABot.Utils
                 "1.18" => MCVersion.v118,
                 "1.16-fabric" => MCVersion.v116,
                 "1.18-fabric" => MCVersion.v118,
+                "1.19" => MCVersion.v119,
+                // "1.19-fabric" => MCVersion.v119,
                 _ => throw new ArgumentOutOfRangeException(nameof(version), version, null)
             };
         }
@@ -72,7 +82,7 @@ namespace CFPABot.Utils
         {
             return version switch
             {
-                MCVersion.v116 or MCVersion.v118 or MCVersion.v116fabric or MCVersion.v118fabric => "zh_cn.json",
+                MCVersion.v116 or MCVersion.v118 or MCVersion.v116fabric or MCVersion.v118fabric or MCVersion.v119 => "zh_cn.json",
                 MCVersion.v1122 => "zh_cn.lang",
                 _ => throw new ArgumentOutOfRangeException(nameof(version), version, null)
             };
@@ -82,7 +92,7 @@ namespace CFPABot.Utils
         {
             return version switch
             {
-                MCVersion.v116 or MCVersion.v118 or MCVersion.v116fabric or MCVersion.v118fabric => "en_us.json",
+                MCVersion.v116 or MCVersion.v118 or MCVersion.v116fabric or MCVersion.v118fabric or MCVersion.v119 => "en_us.json",
                 MCVersion.v1122 => "en_us.lang",
                 _ => throw new ArgumentOutOfRangeException(nameof(version), version, null)
             };


### PR DESCRIPTION
主要提交pr的原因是最近cfpa开始尝试支持1.19，但是bot无法正确处理1.19的pr，甚至在含1.19的pr中，其他版本的模组列表功能也失效了，我就想着自己来看一下
其实只在`MCVersion.cs`里的`MCVersion`枚举类里添加一个1.19的枚举，然后更新下`MCVersionExtensions`类里的对应方法就行了。我自己简单用vs翻查了一下源码，没有发现其他文件中存在**可能无法处理新枚举项的代码**。
如果由于未开源、不想增加贡献者等原因，无法或不希望merge此pr，请直接关闭此pr。