### PR TITLE
feat: 添加对Modrinth数据包和CurseForge材质包的支持

### DIFF
--- a/CFPABot/Azusa/Pages/Diff.razor
+++ b/CFPABot/Azusa/Pages/Diff.razor
@@ -740,6 +740,34 @@
 
         try
         {
+            if (slug.StartsWith("modrinth-datapack-"))
+            {
+                slug = slug["modrinth-datapack-".Length..];
+                var addon = await ModrinthManager.GetMod(slug);
+                foreach (var modVersion in versions)
+                {
+                    var loaders = new[] { "datapack" };
+                    var modEnFile = await ModrinthManager.GetModEnFile(addon, modVersion.ToVersionDirectory().ToMCVersion(), loaders, LangType.EN);
+                    var modCnFile = await ModrinthManager.GetModEnFile(addon, modVersion.ToVersionDirectory().ToMCVersion(), loaders, LangType.CN);
+
+                    if (modEnFile.files != null && modEnFile.files.FirstOrDefault() is { } f2)
+                    {
+                        var s = $"{modCnFile.downloadFileName} 的英文语言文件";
+
+                        textsV.Add(s);
+                        langV.Add(LangFileWrapper.FromContent(f2));
+                    }
+
+                    if (modCnFile.files != null && modCnFile.files.FirstOrDefault() is { } f)
+                    {
+                        var s = $"{modCnFile.downloadFileName} 的中文语言文件";
+
+                        textsV.Add(s);
+                        langV.Add(LangFileWrapper.FromContent(f));
+                    }
+                }
+                return;
+            }
             if (slug.StartsWith("modrinth-"))
             {
                 slug = slug["modrinth-".Length..];
@@ -766,6 +794,32 @@
                     }
                 }
                 return;
+            }
+            else if (slug.StartsWith("texture-packs-"))
+            {
+                slug = slug["texture-packs-".Length..];
+                var addon = await CurseManager.GetAddon(slug);
+                foreach (var modVersion in versions)
+                {
+                    var modEnFile = await CurseManager.GetModEnFile(addon, modVersion.ToVersionDirectory().ToMCVersion(), LangType.EN);
+                    var modCnFile = await CurseManager.GetModEnFile(addon, modVersion.ToVersionDirectory().ToMCVersion(), LangType.CN);
+
+                    if (modEnFile.files != null && modEnFile.files.FirstOrDefault() is { } f2)
+                    {
+                        var s = $"{modCnFile.downloadFileName} 的英文语言文件";
+
+                        textsV.Add(s);
+                        langV.Add(LangFileWrapper.FromContent(f2));
+                    }
+
+                    if (modCnFile.files != null && modCnFile.files.FirstOrDefault() is { } f)
+                    {
+                        var s = $"{modCnFile.downloadFileName} 的中文语言文件";
+
+                        textsV.Add(s);
+                        langV.Add(LangFileWrapper.FromContent(f));
+                    }
+                }
             }
             else
             {

--- a/CFPABot/Command/CommandProcessor.cs
+++ b/CFPABot/Command/CommandProcessor.cs
@@ -153,7 +153,42 @@ namespace CFPABot.Command
                             MCVersion.v1122 => "en_us.lang",
                             _ => "en_us.json"
                         };
-                        if (curseForgeID.StartsWith("modrinth-"))
+                        if (curseForgeID.StartsWith("modrinth-datapack-"))
+                        {
+                            var originalID = curseForgeID;
+                            curseForgeID = curseForgeID["modrinth-datapack-".Length..];
+                            var addon = await ModrinthManager.GetMod(curseForgeID);
+
+                            var modID = await ModrinthManager.GetModID(addon, version, new[] { "datapack" }, true, false);
+                            var (files, downloadFileName) = await ModrinthManager.GetModEnFile(addon, version, new[] { "datapack" }, LangType.EN);
+                            if (files.Length != 1)
+                            {
+                                sb.AppendLine(Locale.Command_update_en_MultipleLangFiles);
+                                continue;
+                            }
+
+                            sb.AppendLine(string.Format(Locale.Command_update_en_Success, downloadFileName));
+                            var f = files[0];
+                            using var sr = new MemoryStream(f.ToUTF8Bytes()).CreateStreamReader(Encoding.UTF8);
+                            using var sw = File.Open(
+                                Path.Combine(r.WorkingDirectory,
+                                    $"projects/assets/{curseForgeID}/{versionString}/{modID}/lang/{versionFile}"),
+                                FileMode.Create).CreateStreamWriter(new UTF8Encoding(false));
+
+                            switch (version)
+                            {
+                                case MCVersion.v1122:
+                                    new LangFormatter(sr, sw).Format();
+                                    break;
+                                default:
+                                    new JsonFormatter(sr, sw).Format();
+                                    break;
+                            }
+
+                            r.AddAllFiles();
+                            r.Commit($"Update en_us file for {(curseForgeID.Replace("\"", "\\\""))}", user);
+                        }
+                        else if (curseForgeID.StartsWith("modrinth-"))
                         {
                             curseForgeID = curseForgeID["modrinth-".Length..];
                             var addon = await ModrinthManager.GetMod(curseForgeID);
@@ -171,7 +206,42 @@ namespace CFPABot.Command
                             using var sr = new MemoryStream(f.ToUTF8Bytes()).CreateStreamReader(Encoding.UTF8);
                             using var sw = File.Open(
                                 Path.Combine(r.WorkingDirectory,
-                                    $"projects/{versionString}/assets/{curseForgeID}/{modID}/lang/{versionFile}"),
+                                    $"projects/assets/{curseForgeID}/{versionString}/{modID}/lang/{versionFile}"),
+                                FileMode.Create).CreateStreamWriter(new UTF8Encoding(false));
+
+                            switch (version)
+                            {
+                                case MCVersion.v1122:
+                                    new LangFormatter(sr, sw).Format();
+                                    break;
+                                default:
+                                    new JsonFormatter(sr, sw).Format();
+                                    break;
+                            }
+
+                            r.AddAllFiles();
+                            r.Commit($"Update en_us file for {(curseForgeID.Replace("\"", "\\\""))}", user);
+                        }
+                        else if (curseForgeID.StartsWith("texture-packs-"))
+                        {
+                            var originalID = curseForgeID;
+                            curseForgeID = curseForgeID["texture-packs-".Length..];
+                            var addon = await CurseManager.GetAddon(curseForgeID);
+
+                            var modID = await CurseManager.GetModID(addon, version, true, false);
+                            var (files, downloadFileName) = await CurseManager.GetModEnFile(addon, version, LangType.EN);
+                            if (files.Length != 1)
+                            {
+                                sb.AppendLine(Locale.Command_update_en_MultipleLangFiles);
+                                continue;
+                            }
+
+                            sb.AppendLine(string.Format(Locale.Command_update_en_Success, downloadFileName));
+                            var f = files[0];
+                            using var sr = new MemoryStream(f.ToUTF8Bytes()).CreateStreamReader(Encoding.UTF8);
+                            using var sw = File.Open(
+                                Path.Combine(r.WorkingDirectory,
+                                    $"projects/assets/{curseForgeID}/{versionString}/{modID}/lang/{versionFile}"),
                                 FileMode.Create).CreateStreamWriter(new UTF8Encoding(false));
 
                             switch (version)
@@ -204,7 +274,7 @@ namespace CFPABot.Command
                             using var sr = new MemoryStream(f.ToUTF8Bytes()).CreateStreamReader(Encoding.UTF8);
                             using var sw = File.Open(
                                 Path.Combine(r.WorkingDirectory,
-                                    $"projects/{versionString}/assets/{curseForgeID}/{modID}/lang/{versionFile}"),
+                                    $"projects/assets/{curseForgeID}/{versionString}/{modID}/lang/{versionFile}"),
                                 FileMode.Create).CreateStreamWriter(new UTF8Encoding(false));
 
                             switch (version)
@@ -220,7 +290,7 @@ namespace CFPABot.Command
                             r.AddAllFiles();
                             r.Commit($"Update en_us file for {(curseForgeID.Replace("\"", "\\\""))}", user);
                         }
-                        
+
                     }
 
                     if (line.StartsWith("/add-co-author "))

--- a/CFPABot/Controllers/UtilsController.cs
+++ b/CFPABot/Controllers/UtilsController.cs
@@ -93,11 +93,23 @@ namespace CFPABot.Controllers
         {
             try
             {
-                if (slug.StartsWith("modrinth-"))
+                if (slug.StartsWith("modrinth-datapack-"))
+                {
+                    slug = slug["modrinth-datapack-".Length..];
+                    var mod = await ModrinthManager.GetMod(slug);
+                    return Content(mod.Title);
+                }
+                else if (slug.StartsWith("modrinth-"))
                 {
                     slug = slug["modrinth-".Length..];
                     var mod = await ModrinthManager.GetMod(slug);
                     return Content(mod.Title);
+                }
+                else if (slug.StartsWith("texture-packs-"))
+                {
+                    slug = slug["texture-packs-".Length..];
+                    var mod = await CurseManager.GetAddon(slug);
+                    return Content(mod.Name);
                 }
                 else
                 {

--- a/CFPABot/Utils/CommentBuilder.cs
+++ b/CFPABot/Utils/CommentBuilder.cs
@@ -225,7 +225,7 @@ namespace CFPABot.Utils
 
                 var addons = new List<Mod>();
                 var tasks = new List<Task>();
-                foreach (var modid in modids.Where(x => x != "1UNKNOWN" && x != "0-modrinth-mod" && !x.StartsWith("modrinth-")))
+                foreach (var modid in modids.Where(x => x != "1UNKNOWN" && x != "0-modrinth-mod" && !x.StartsWith("modrinth-") && !x.StartsWith("texture-packs-") && !x.StartsWith("modrinth-datapack-")))
                 {
                     tasks.Add(Task.Run(async () =>
                     {
@@ -248,7 +248,7 @@ namespace CFPABot.Utils
                 var client = new ModrinthClient();
 
 
-                var modrinthMods = modInfos.Where(x => x.CurseForgeID.StartsWith("modrinth-")).Select(m => m.CurseForgeID.Substring("modrinth-".Length)).Distinct().ToArray();
+                var modrinthMods = modInfos.Where(x => x.CurseForgeID.StartsWith("modrinth-") && !x.CurseForgeID.StartsWith("modrinth-datapack-")).Select(m => m.CurseForgeID.Substring("modrinth-".Length)).Distinct().ToArray();
 
                 var sbModrinthError = new StringBuilder();
                 var modrinthList = new List<(string slug, string url, string iconUrl, string name)>();
@@ -314,7 +314,41 @@ namespace CFPABot.Utils
                     sb.AppendLine();
                 }
 
-                if (addons.Count == 0 && modrinthList.Count == 0)
+                // texture-packs (CurseForge 材质包)
+                var texturePackSlugs = modInfos.Where(x => x.CurseForgeID.StartsWith("texture-packs-"))
+                    .Select(m => m.CurseForgeID.Substring("texture-packs-".Length)).Distinct().ToArray();
+                var texturePackList = new List<(string prefixedSlug, Mod addon)>();
+                foreach (var realSlug in texturePackSlugs)
+                {
+                    try
+                    {
+                        var addon = await CurseManager.GetAddon(realSlug);
+                        texturePackList.Add(($"texture-packs-{realSlug}", addon));
+                    }
+                    catch (CheckException e)
+                    {
+                        lock (sb) { sb.AppendLine(e.Message); }
+                    }
+                }
+
+                // modrinth-datapack (Modrinth 数据包)
+                var datapackMods = modInfos.Where(x => x.CurseForgeID.StartsWith("modrinth-datapack-"))
+                    .Select(m => m.CurseForgeID.Substring("modrinth-datapack-".Length)).Distinct().ToArray();
+                var datapackList = new List<(string prefixedSlug, string url, string iconUrl, string name)>();
+                foreach (var realSlug in datapackMods)
+                {
+                    try
+                    {
+                        var project = await client.Project.GetAsync(realSlug);
+                        datapackList.Add(($"modrinth-datapack-{realSlug}", project.Url, project.IconUrl, project.Title));
+                    }
+                    catch (ModrinthApiException e)
+                    {
+                        sb.AppendLine($"Modrinth Datapack 检索遇到问题：{e.Message}");
+                    }
+                }
+
+                if (addons.Count == 0 && modrinthList.Count == 0 && texturePackList.Count == 0 && datapackList.Count == 0)
                 {
                     sb.AppendLine("ℹ 此 PR 没有检测到 CurseForge/Modrinth 模组修改。");
                     return;
@@ -338,6 +372,35 @@ namespace CFPABot.Utils
                                    ""
                     );
                     modCount++;
+                }
+
+                foreach (var (prefixedSlug, url, iconUrl, name) in datapackList)
+                {
+                    sb1.AppendLine($"| " +
+                    /* Thumbnail*/ $"<image src=\"{iconUrl}\" width=\"32\"/> |" +
+                                   /* Mod Name */ $" [**{name.Trim().Replace("[", "\\[").Replace("]", "\\]").Replace("|", "\\|")}**]({url}) |" +
+                                   /* Source   */ $" " +
+                                   /* Mcmod    */ $" [🟩 MCMOD](https://cn.bing.com/search?q=site:mcmod.cn%20{HttpUtility.UrlEncode(name)}) \\|" +
+                                   /* Compare  */ $" [:file_folder: 对比(Azusa)](https://cfpa.cyan.cafe/Azusa/Diff/{PullRequestID}/{prefixedSlug}) |" +
+                                   /* Mod DL   */ $" Modrinth Datapack |" +
+                                   ""
+                    );
+                    modCount++;
+                }
+
+                foreach (var (prefixedSlug, addon) in texturePackList)
+                {
+                    Interlocked.Increment(ref modCount);
+                    var infos = modInfos.Where(i => i.CurseForgeID == prefixedSlug).ToArray();
+                    var versions = infos.Select(i => i.Version).ToArray();
+                    sb1.AppendLine($"| " +
+                        /* Thumbnail*/ $"{await CurseManager.GetThumbnailText(addon).ConfigureAwait(false)} |" +
+                        /* Mod Name */ $" [**{addon.Name.Trim().Replace("[", "\\[").Replace("]", "\\]").Replace("|", "\\|")}**]({addon.Links.WebsiteUrl}) |" +
+                        /* Source   */ $" {CurseManager.GetRepoText(addon)} \\|" +
+                        /* Mcmod    */ $" [🟩 MCMOD](https://cn.bing.com/search?q=site:mcmod.cn%20{HttpUtility.UrlEncode(addon.Name)}) \\|" +
+                        /* Compare  */ $" [:file_folder: 对比(Azusa)](https://cfpa.cyan.cafe/Azusa/Diff/{PullRequestID}/{prefixedSlug}) |" +
+                        /* Mod DL   */ $" {await CurseManager.GetModRepoLinkText(addon, infos).ConfigureAwait(false)} |" +
+                    "");
                 }
 
                 foreach (var addon in addons.AsParallel().AsSequential().Select(async d1 =>
@@ -902,13 +965,33 @@ namespace CFPABot.Utils
                             try
                             {
                                 var slug = names[3];
-                                if (slug.StartsWith("modrinth-"))
+                                if (slug.StartsWith("modrinth-datapack-"))
+                                {
+                                    var realSlug = slug["modrinth-datapack-".Length..];
+                                    var addon = await ModrinthManager.GetMod(realSlug);
+                                    var modDomain =
+                                        await ModrinthManager.GetModID(addon, names[1].ToMCStandardVersion(), new[] { "datapack" }, true, false);
+                                    var rdir = $"projects/{names[1]}/assets/{slug}/{modDomain}/lang/";
+                                    sb.AppendLine($"  自动找到该模组 Domain 为 `{modDomain}`，可能正确文件夹为 `{rdir}`。使用命令 `/mv \"{names.Take(4).Connect("/")}/\" \"{rdir}\"` 来移动路径。");
+                                    sb.AppendLine();
+                                }
+                                else if (slug.StartsWith("modrinth-"))
                                 {
                                     slug = slug["modrinth-".Length..];
                                     var addon = await ModrinthManager.GetMod(slug);
                                     var modDomain =
                                         await ModrinthManager.GetModID(addon, names[1].ToMCStandardVersion(), true, false);
                                     var rdir = $"projects/{names[1]}/assets/{names[3]}/{modDomain}/lang/";
+                                    sb.AppendLine($"  自动找到该模组 Domain 为 `{modDomain}`，可能正确文件夹为 `{rdir}`。使用命令 `/mv \"{names.Take(4).Connect("/")}/\" \"{rdir}\"` 来移动路径。");
+                                    sb.AppendLine();
+                                }
+                                else if (slug.StartsWith("texture-packs-"))
+                                {
+                                    var realSlug = slug["texture-packs-".Length..];
+                                    var addon = await CurseManager.GetAddon(realSlug);
+                                    var modDomain =
+                                        await CurseManager.GetModID(addon, names[1].ToMCStandardVersion(), true, false);
+                                    var rdir = $"projects/{names[1]}/assets/{slug}/{modDomain}/lang/";
                                     sb.AppendLine($"  自动找到该模组 Domain 为 `{modDomain}`，可能正确文件夹为 `{rdir}`。使用命令 `/mv \"{names.Take(4).Connect("/")}/\" \"{rdir}\"` 来移动路径。");
                                     sb.AppendLine();
                                 }
@@ -942,12 +1025,33 @@ namespace CFPABot.Utils
                                 sb.AppendLine($"⚠ 检测到一个语言文件，但提交路径不正常。缺少了 {{ModDomain}} 或 {{CurseForge 项目名}} 文件夹。请检查提交路径：`{diff.To}`；");
                                 try
                                 {
-                                    var addon = await CurseManager.GetAddon(names[3]);
-                                    var modDomain =
-                                        await CurseManager.GetModID(addon, names[1].ToMCStandardVersion(), true, false);
-                                    var rdir = $"projects/{names[1]}/assets/{names[3]}/{modDomain}/lang/";
-                                    sb.AppendLine($"  自动找到了该模组的 Mod Domain 为 `{modDomain}`，可能的正确文件夹为 `{rdir}`。 你可以使用命令 `/mv \"{names.Take(5).Connect("/")}/\" \"{rdir}\"` 来移动路径。");
-                                    sb.AppendLine();
+                                    var slug = names[3];
+                                    if (slug.StartsWith("modrinth-datapack-"))
+                                    {
+                                        var realSlug = slug["modrinth-datapack-".Length..];
+                                        var addon = await ModrinthManager.GetMod(realSlug);
+                                        var modDomain = await ModrinthManager.GetModID(addon, names[1].ToMCStandardVersion(), new[] { "datapack" }, true, false);
+                                        var rdir = $"projects/{names[1]}/assets/{slug}/{modDomain}/lang/";
+                                        sb.AppendLine($"  自动找到了该模组的 Mod Domain 为 `{modDomain}`，可能的正确文件夹为 `{rdir}`。 你可以使用命令 `/mv \"{names.Take(5).Connect("/")}/\" \"{rdir}\"` 来移动路径。");
+                                        sb.AppendLine();
+                                    }
+                                    else if (slug.StartsWith("texture-packs-"))
+                                    {
+                                        var realSlug = slug["texture-packs-".Length..];
+                                        var addon = await CurseManager.GetAddon(realSlug);
+                                        var modDomain = await CurseManager.GetModID(addon, names[1].ToMCStandardVersion(), true, false);
+                                        var rdir = $"projects/{names[1]}/assets/{slug}/{modDomain}/lang/";
+                                        sb.AppendLine($"  自动找到了该模组的 Mod Domain 为 `{modDomain}`，可能的正确文件夹为 `{rdir}`。 你可以使用命令 `/mv \"{names.Take(5).Connect("/")}/\" \"{rdir}\"` 来移动路径。");
+                                        sb.AppendLine();
+                                    }
+                                    else
+                                    {
+                                        var addon = await CurseManager.GetAddon(names[3]);
+                                        var modDomain = await CurseManager.GetModID(addon, names[1].ToMCStandardVersion(), true, false);
+                                        var rdir = $"projects/{names[1]}/assets/{names[3]}/{modDomain}/lang/";
+                                        sb.AppendLine($"  自动找到了该模组的 Mod Domain 为 `{modDomain}`，可能的正确文件夹为 `{rdir}`。 你可以使用命令 `/mv \"{names.Take(5).Connect("/")}/\" \"{rdir}\"` 来移动路径。");
+                                        sb.AppendLine();
+                                    }
                                 }
                                 catch (Exception)
                                 {
@@ -1030,7 +1134,11 @@ namespace CFPABot.Utils
 
                         try
                         {
-                            if (curseID != "1UNKNOWN" && curseID != "0-modrinth-mod" && !curseID.StartsWith("modrinth-"))
+                            if (curseID.StartsWith("texture-packs-"))
+                            {
+                                addon = await CurseManager.GetAddon(curseID["texture-packs-".Length..]);
+                            }
+                            else if (curseID != "1UNKNOWN" && curseID != "0-modrinth-mod" && !curseID.StartsWith("modrinth-"))
                                 addon = await CurseManager.GetAddon(curseID);
                         }
                         catch (Exception)
@@ -1069,7 +1177,12 @@ namespace CFPABot.Utils
 
                     try
                     {
-                        if (curseID != "1UNKNOWN" && curseID != "0-modrinth-mod" && !curseID.StartsWith("modrinth-"))
+                        if (curseID.StartsWith("texture-packs-"))
+                        {
+                            var realSlug = curseID["texture-packs-".Length..];
+                            addon = await CurseManager.GetAddon(realSlug);
+                        }
+                        else if (curseID != "1UNKNOWN" && curseID != "0-modrinth-mod" && !curseID.StartsWith("modrinth-"))
                             addon = await CurseManager.GetAddon(curseID);
                     }
                     catch (Exception)
@@ -1077,7 +1190,8 @@ namespace CFPABot.Utils
                         sb.AppendLine(string.Format(Locale.Check_ModID_ModNotFound, curseID, versionString));
                     }
 
-                    if (addon != null && addon.Slug != curseID)
+                    var curseIDForApi = curseID.StartsWith("texture-packs-") ? curseID["texture-packs-".Length..] : curseID;
+                    if (addon != null && addon.Slug != curseIDForApi)
                     {
                         sb.AppendLine("❌ 检测到此模组作者更改了 Slug 名，请使用以下命令进行路径移动：");
                         sb.AppendLine("```");
@@ -1126,7 +1240,9 @@ namespace CFPABot.Utils
                     Project z = null;
                     try
                     {
-                        if (curseID.StartsWith("modrinth-"))
+                        if (curseID.StartsWith("modrinth-datapack-"))
+                            z = await ModrinthManager.GetMod(curseID["modrinth-datapack-".Length..]);
+                        else if (curseID.StartsWith("modrinth-"))
                             z = await ModrinthManager.GetMod(curseID["modrinth-".Length..]);
                     }
                     catch (Exception)
@@ -1136,7 +1252,9 @@ namespace CFPABot.Utils
                     if (z != null)
                         try
                         {
-                            var filemodid = await ModrinthManager.GetModIDForCheck(z, mcVersion);
+                            var filemodid = curseID.StartsWith("modrinth-datapack-")
+                                ? await ModrinthManager.GetModIDForCheck(z, mcVersion, new[] { "datapack" })
+                                : await ModrinthManager.GetModIDForCheck(z, mcVersion);
                             if (filemodid == null || filemodid.Length == 0)
                             {
                                 sb.AppendLine(string.Format(Locale.Check_ModID_ModIDNotFound, "modrinth~" + modid));

--- a/CFPABot/Utils/CurseManager.cs
+++ b/CFPABot/Utils/CurseManager.cs
@@ -546,7 +546,7 @@ namespace CFPABot.Utils
 
         static void AddMapping(List<Mod> addons)
         {
-            foreach (var addon in addons.Where(s => s.GameId == 432 && s.Links.WebsiteUrl.StartsWith("https://www.curseforge.com/minecraft/mc-mods/")))
+            foreach (var addon in addons.Where(s => s.GameId == 432 && (s.Links.WebsiteUrl.StartsWith("https://www.curseforge.com/minecraft/mc-mods/") || s.Links.WebsiteUrl.StartsWith("https://www.curseforge.com/minecraft/texture-packs/"))))
                 lock (ModIDMappingMetadata.Instance)
                 {
                     ModIDMappingMetadata.Instance.Mapping[addon.Slug] = (int)addon.Id;

--- a/CFPABot/Utils/ModrinthManager.cs
+++ b/CFPABot/Utils/ModrinthManager.cs
@@ -21,13 +21,20 @@ namespace CFPABot.Utils
             return Instance.Project.GetAsync(slug);
         }
 
-        public static async Task<string> GetModID(Project addon, MCVersion? version, bool enforcedLang = false,
+        static string[] DefaultLoaders(MCVersion? version) =>
+            version?.ToString().Contains("fabric") == true ? new[] { "fabric" } : new[] { "fabric", "forge" };
+
+        public static Task<string> GetModID(Project addon, MCVersion? version, bool enforcedLang = false,
+    bool connect = true)
+            => GetModID(addon, version, DefaultLoaders(version), enforcedLang, connect);
+
+        public static async Task<string> GetModID(Project addon, MCVersion? version, string[] loaders, bool enforcedLang = false,
     bool connect = true)
         {
             if (version == null) return "未知";
             try
             {
-                var versions = await Instance.Version.GetProjectVersionListAsync(addon.Slug, new []{ version.ToString().Contains("fabric") ? "fabric": "forge"});
+                var versions = await Instance.Version.GetProjectVersionListAsync(addon.Slug, loaders);
                 if (versions.FirstOrDefault(f => f.GameVersions.Any(x=> x.StartsWith(version.Value.ToStandardVersionString()))) is { } file)
                 {
                     var fileName = await Download.DownloadFile(file.Files.First().Url); // 我好累
@@ -51,12 +58,15 @@ namespace CFPABot.Utils
             return "未知";
         }
 
-        public static async Task<string[]> GetModIDForCheck(Project addon, MCVersion? version)
+        public static Task<string[]> GetModIDForCheck(Project addon, MCVersion? version)
+            => GetModIDForCheck(addon, version, DefaultLoaders(version));
+
+        public static async Task<string[]> GetModIDForCheck(Project addon, MCVersion? version, string[] loaders)
         {
             if (version == null) return null;
             try
             {
-                var versions = await Instance.Version.GetProjectVersionListAsync(addon.Slug, new []{ version.ToString().Contains("fabric") ? "fabric": "forge"});
+                var versions = await Instance.Version.GetProjectVersionListAsync(addon.Slug, loaders);
                 if (versions.Where(x => x.GameVersions.Any(y => y.StartsWith(version.Value.ToStandardVersionString()))).FirstOrDefault() is {} file)
                 {
                     var fileName = await Download.DownloadFile(file.Files.Any(x => x.FileName.ToLower().Contains("fabric") && version.ToString().Contains("fabric"))?file.Files.First(x => x.FileName.ToLower().Contains("fabric")).Url: file.Files.First().Url);
@@ -79,12 +89,15 @@ namespace CFPABot.Utils
             return null;
         }
 
-        public static async Task<(string[] files, string downloadFileName)> GetModEnFile(Project addon, MCVersion? version, LangType type)
+        public static Task<(string[] files, string downloadFileName)> GetModEnFile(Project addon, MCVersion? version, LangType type)
+            => GetModEnFile(addon, version, DefaultLoaders(version), type);
+
+        public static async Task<(string[] files, string downloadFileName)> GetModEnFile(Project addon, MCVersion? version, string[] loaders, LangType type)
         {
             if (version == null) return (null, null);
             try
             {
-                var versions = await Instance.Version.GetProjectVersionListAsync(addon.Slug, new[] { version.ToString().Contains("fabric") ? "fabric" : "forge" });
+                var versions = await Instance.Version.GetProjectVersionListAsync(addon.Slug, loaders);
                 if (versions.Where(x => x.GameVersions.Any(y => y.StartsWith(version.Value.ToStandardVersionString()))).FirstOrDefault() is { } file)
                 {
                     var d = file.Files.Any(x => x.FileName.ToLower().Contains("fabric") && version.ToString().Contains("fabric")) ? file.Files.First(x => x.FileName.ToLower().Contains("fabric")) : file.Files.First();


### PR DESCRIPTION
### 背景

CFPABot 目前只支持从 CurseForge 的 `mc-mods` 分类爬取模组数据。社区收到了来自 `texture-packs`（材质包）分类的翻译 PR，以及 Modrinth 上 `datapack`（数据包）分类的翻译需求。需要扩展 Bot 的前缀系统来支持新的内容类型。

### 变更概要

新增两个路径前缀，用于在仓库路径中标识内容来源类型：

```
projects/assets/texture-packs-{slug}/{version}/{modid}/lang/zh_cn.json
projects/assets/modrinth-datapack-{slug}/{version}/{modid}/lang/zh_cn.json
```

### 详细文件变更

#### 1. `CurseManager.cs` — 映射自动发现

- `CurseForgeIDMappingManager.AddMapping` 在 CurseForge API 批量查询映射时，除了现有的 `mc-mods/` URL 前缀，额外收录 `https://www.curseforge.com/minecraft/texture-packs/` 下的项目。mapping 字典以真实 slug（无前缀）为 key，路径中的 `texture-packs-` 前缀在使用前剥离。

#### 2. `ModrinthManager.cs` — 支持自定义 Loader

- `GetModID` / `GetModIDForCheck` / `GetModEnFile` 各新增一个带 `string[] loaders` 参数的重载
- `DefaultLoaders` 辅助方法：默认返回 `["fabric", "forge"]`
- datapack 场景传入 `["datapack"]` 作为 loader 过滤条件

#### 3. `CommentBuilder.cs` — Bot 评论 & 检查

**`UpdateModLinkSegment`**（Bot 评论的模组列表段）：
- 主 CurseForge 循环过滤掉 `texture-packs-`、`modrinth-datapack-` 前缀的项
- **texture-packs 处理段**：剥离前缀 → CurseManager API → 渲染表格行（Compare URL 使用 `texture-packs-{slug}`）
- **modrinth-datapack 处理段**：剥离前缀 → ModrinthManager API（datapack loader）→ 渲染表格行（Compare URL 使用 `modrinth-datapack-{slug}`）
- 更新"无模组"判定条件，纳入新列表

**`UpdateCheckSegment`**（Bot 评论的检查段）：
- CurseForge 查找：`texture-packs-` 剥离前缀后调用 CurseManager
- Modrinth 查找：`modrinth-datapack-` 剥离前缀后调用 ModrinthManager，`GetModIDForCheck` 使用 `["datapack"]` loader
- 路径验证段（`names.Length == 5` / `6`）：增加新前缀分支，自动检测 Mod Domain 并提供 `/mv` 修复建议
- Slug 变更检测：对 `texture-packs-` 前缀使用剥离后的 slug 做比较，避免误报

#### 4. `CommandProcessor.cs` — `/update-en` 命令

- 新增 `modrinth-datapack-` 分支：剥离前缀 → `ModrinthManager.GetMod` → 使用 `["datapack"]` loader → 写入 `projects/assets/{slug}/...`
- 新增 `texture-packs-` 分支：剥离前缀 → `CurseManager.GetAddon` → 写入 `projects/assets/{slug}/...`
- 按 `modrinth-datapack-` > `modrinth-` > `texture-packs-` > 普通 CurseForge 的顺序匹配

#### 5. `UtilsController.cs` — API 端点

- `GetModName`：增加 `modrinth-datapack-`（Modrinth API）和 `texture-packs-`（CurseForge API）的处理分支

#### 6. `Diff.razor` — Azusa 比较页面

- `GetModFiles`：增加 `modrinth-datapack-`（使用 `["datapack"]` loader）和 `texture-packs-`（CurseForge API）的处理分支

### 路径约定说明

所有四个来源在仓库中的路径格式统一为 `projects/assets/{slug}/...`：

| 前缀 | 来源 | slug 取值 |
|---|---|---|
| (无) | CurseForge mc-mods | 直接使用 CurseForge slug |
| `modrinth-` | Modrinth mods | 剥离前缀后的真实 Modrinth slug |
| `texture-packs-` | CurseForge texture-packs | 剥离前缀后的真实 CurseForge slug |
| `modrinth-datapack-` | Modrinth datapacks | 剥离前缀后的真实 Modrinth slug |

前缀仅在 `ModInfo.CurseForgeID`（从 PR 路径提取的标识符）中用于识别来源类型。API 调用和路径构造均使用剥离前缀后的真实 slug。

### 向后兼容

- 所有现有功能不受影响
- 新增前缀对现有流程完全透明
- 不涉及数据库迁移或配置变更